### PR TITLE
Modify email filter example to more generic one

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following code to your `captainhook.json` configuration file:
         "action": "\\bitExpert\\CaptainHook\\ValidateAuthor\\ValidateAuthorAction",
         "options": {
             "name": "/^[A-Za-z0-09]+$/",
-            "email": "/mydomain.loc/",
+            "email": "/@example.com$/",
         }
       }
     ]


### PR DESCRIPTION
This changes the email-filter example to a more generic one (example. com instead of a possibly existing domain name) that also enforces the domain part to be explicitly the one in the example and not merely containing the example somewhere. Before an email address of "mydomain. loc@example.com" would have been valid as well.