### PR TITLE
Derive author from `git var GIT_AUTHOR_IDENT`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   ],
   "require": {
     "php": "^8.0.0|^8.1.0|^8.2.0",
-    "captainhook/captainhook": "^5.12.0"
+    "captainhook/captainhook": "^5.12.0",
+    "sebastianfeldmann/git": "^3.14.0"
   },
   "require-dev": {
     "bitexpert/captainhook-infection": "^0.7.0",

--- a/src/bitExpert/CaptainHook/ValidateAuthor/GitIdentity.php
+++ b/src/bitExpert/CaptainHook/ValidateAuthor/GitIdentity.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Captain Hook Validate Author plugin package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace bitExpert\CaptainHook\ValidateAuthor;
+
+final class GitIdentity
+{
+    public function __construct(private string $name, private string $email)
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * Parses a git identity from an ident string as returned by e.g.
+     * `git var GIT_AUTHOR_IDENT` or `git var GIT_COMMITTER_IDENT`.
+     *
+     * @param string $ident
+     * @return self
+     */
+    public static function fromIdentString(string $ident): self
+    {
+        if (!(bool)preg_match('/^([^<]+) <([^>]+)>/', $ident, $matches)) {
+            throw new \RuntimeException('Could not parse git ident string');
+        }
+
+        return new self($matches[1], $matches[2]);
+    }
+}

--- a/tests/bitExpert/CaptainHook/ValidateAuthor/GitIdentityUnitTest.php
+++ b/tests/bitExpert/CaptainHook/ValidateAuthor/GitIdentityUnitTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Captain Hook Validate Author plugin package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace bitExpert\CaptainHook\ValidateAuthor;
+
+use PHPUnit\Framework\TestCase;
+
+class GitIdentityUnitTest extends TestCase
+{
+    /**
+     * @test
+     * @see https://git-scm.com/docs/git-var#_examples
+     */
+    public function parsesGitIdentStringToNameAndEmail(): void
+    {
+        $ident = GitIdentity::fromIdentString('Eric W. Biederman <ebiederm@lnxi.com> 1121223278 -0600');
+        self::assertSame('Eric W. Biederman', $ident->getName());
+        self::assertSame('ebiederm@lnxi.com', $ident->getEmail());
+    }
+}

--- a/tests/bitExpert/CaptainHook/ValidateAuthor/ValidateAuthorActionUnitTest.php
+++ b/tests/bitExpert/CaptainHook/ValidateAuthor/ValidateAuthorActionUnitTest.php
@@ -58,7 +58,7 @@ class ValidateAuthorActionUnitTest extends TestCase
         $this->io = $this->createMock(IO::class);
         $this->repository = $this->createMock(Repository::class);
         $this->action = $this->createMock(Action::class);
-        $this->hook = $this->createPartialMock(ValidateAuthorAction::class, ['getConfig']);
+        $this->hook = $this->createPartialMock(ValidateAuthorAction::class, ['getGitAuthorIdentity']);
     }
 
     /**
@@ -71,7 +71,7 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options([]));
 
         $this->hook->expects(self::never())
-            ->method('getConfig');
+            ->method('getGitAuthorIdentity');
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -86,9 +86,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['name' => '/Some author name/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.name')
-            ->willReturn('Some author name');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('Some author name', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -103,9 +103,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['name' => '/[A-F]+/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.name')
-            ->willReturn('ABCDEF');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('ABCDEF', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -122,9 +122,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['name' => '/^[1-9]+$/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.name')
-            ->willReturn('ABCDEF');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('ABCDEF', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -139,9 +139,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['email' => '/test@test.loc/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.email')
-            ->willReturn('test@test.loc');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('Some author name', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -156,9 +156,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['email' => '/@/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.email')
-            ->willReturn('test@test.loc');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('Some author name', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -175,9 +175,9 @@ class ValidateAuthorActionUnitTest extends TestCase
             ->willReturn(new Options(['email' => '/^[1-9]+$/']));
 
         $this->hook->expects(self::once())
-            ->method('getConfig')
-            ->with($this->repository, 'user.email')
-            ->willReturn('test@test.loc');
+            ->method('getGitAuthorIdentity')
+            ->with($this->repository)
+            ->willReturn(new GitIdentity('Some author name', 'test@test.loc'));
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }


### PR DESCRIPTION
This is more accurate than retrieving the name and email using `git config`, as that does not take environment variables and command line flags into account.

Fixes https://github.com/bitExpert/captainhook-validateauthor/issues/57